### PR TITLE
Linux rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,40 +31,11 @@ This tool is particularly useful for creating training datasets for machine lear
 
 ## Installation
 
-### Step 1: Install GIMP 2.10
+### Step 1: Clone the Repository and Create the Conda Environment
 
-> **IMPORTANT:** You must install GIMP version **2.10.x** — not GIMP 3.0 or later. The `gimpformats` Python library and the Spectrace plugin both require GIMP 2.10. **Do not install 3.0**
+You must have first installed [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install/overview) and [Git]([https://git-scm.com/install/) on your system.
 
-
-**macOS:**
-
-Download the `.dmg` from the [Spectrace releases page](https://github.com/JacobGlennAyers/spectrace/releases/tag/correct_gimp_version). Alternatively:
-
-```bash
-brew install gimp@2.10
-```
-
-**Windows:**
-
-1. Download `gimp-2.10.30-setup.exe` from the [Spectrace releases page](https://github.com/JacobGlennAyers/spectrace/releases/tag/correct_gimp_version)
-2. Run the installer and accept default settings
-
-**Linux (Ubuntu/Debian):**
-
-```bash
-sudo apt update && sudo apt install gimp=2.10.*
-```
-
-If GIMP 2.10 is not in your distribution's repositories, use Flatpak:
-
-```bash
-flatpak install flathub org.gimp.GIMP//2.10
-flatpak run org.gimp.GIMP//2.10
-```
-
-**After installing, launch GIMP once and then close it.** This creates the configuration directory that the Spectrace installer needs.
-
-### Step 2: Clone the Repository and Create the Conda Environment
+Navigate to the folder you want the spectrace folder to exist in via a terminal with conda configured - 
 
 ```bash
 git clone https://github.com/JacobGlennAyers/spectrace.git
@@ -86,6 +57,34 @@ This installs all Python dependencies:
 | openpyxl | Excel export |
 | scikit-learn | ML utilities |
 
+### Step 2: Install GIMP 2.10.x
+
+> **IMPORTANT:** You must install GIMP version **2.10.x** — not GIMP 3.0 or later. The `gimpformats` Python library and the Spectrace plugin both require GIMP 2.10. **Do not install 3.0**
+
+
+**macOS:**
+
+Download the `.dmg` from the [Spectrace releases page](https://github.com/JacobGlennAyers/spectrace/releases/tag/correct_gimp_version). 
+
+Double click on the .dmg file in downloads and follow the macOS instructions.
+
+**Windows:**
+
+1. Download `gimp-2.10.30-setup.exe` from the [Spectrace releases page](https://github.com/JacobGlennAyers/spectrace/releases/tag/correct_gimp_version)
+2. Run the installer and accept default settings
+
+**Linux (Ubuntu/Debian):**
+
+Running - 
+```bash
+bash install-gimp-linux.sh
+```
+will automatically add GIMP 2.10.38 to your Applications and create a Desktop Icon. 
+
+
+**After installing, launch GIMP once and then close it.** This creates the configuration directory that the Spectrace installer needs.
+
+
 ### Step 3: Install the Spectrace GIMP Plugin
 
 Run the installer (works on macOS, Linux, and Windows):
@@ -100,7 +99,6 @@ The installer automatically:
 3. Detects your conda `spectrace` environment and writes the path to `~/.spectrace/config.json`
 4. Backs up your original GIMP configuration (restored when you uninstall)
 
-> **Note:** The Linux installer auto-detects both standard (`~/.config/GIMP/2.10`) and Flatpak GIMP installations.
 
 ### Step 4: Verify the Installation
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This tool is particularly useful for creating training datasets for machine lear
 
 ### Step 1: Clone the Repository and Create the Conda Environment
 
-You must have first installed [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install/overview) and [Git]([https://git-scm.com/install/) on your system.
+You must have first installed [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install/overview) and [Git](https://git-scm.com/install/) on your system.
 
 Navigate to the folder you want the spectrace folder to exist in via a terminal with conda configured - 
 

--- a/gimp_plugin/install.py
+++ b/gimp_plugin/install.py
@@ -29,6 +29,46 @@ CONFIG_FILES = ["gimprc", "menurc", "toolrc", "sessionrc"]
 # and avoid backing them up over the user's originals.
 SPECTRACE_MARKER = "# Spectrace GIMP configuration"
 
+# gimprc content for platforms where the menubar must stay visible.
+# config/gimprc uses show-menubar no (macOS only — right-click canvas works
+# there).  Windows and Linux both need show-menubar yes because GTK
+# right-click context menus do not reliably expose the Filters menu.
+_GIMPRC_MENUBAR_YES = """\
+{marker}
+(default-view
+    (show-menubar yes)
+    (show-statusbar yes)
+    (show-rulers no)
+    (show-scrollbars yes)
+    (show-selection yes)
+    (show-layer-boundary no)
+    (show-canvas-boundary no)
+    (show-guides no)
+    (show-grid no)
+    (show-sample-points no))
+(default-fullscreen-view
+    (show-menubar yes)
+    (show-statusbar yes)
+    (show-rulers no)
+    (show-scrollbars yes)
+    (show-selection yes)
+    (show-layer-boundary no)
+    (show-canvas-boundary no)
+    (show-guides no)
+    (show-grid no)
+    (show-sample-points no))
+(toolbox-color-area yes)
+(toolbox-foo-area no)
+(toolbox-image-area no)
+(toolbox-wilber no)
+(can-change-accels no)
+(save-accels yes)
+(restore-accels yes)
+(save-session-info no)
+(save-tool-options no)
+(save-device-status no)
+"""
+
 
 # ── GIMP directory detection ────────────────────────────────────────
 
@@ -177,6 +217,8 @@ def install(gimp_dir):
     print("Spectrace root: %s" % SPECTRACE_ROOT)
     print()
 
+    system = platform.system()
+
     # Back up existing configs — but only if they are NOT already one of
     # ours.  Without this guard a user who ran an old installer would have
     # a spectrace gimprc (with show-menubar no) as their ".original", and
@@ -208,70 +250,27 @@ def install(gimp_dir):
         os.chmod(plugin_dst, 0o755)
     print("  -> Done")
 
-    # 2-5. Install config files
-    # On Windows we write gimprc inline (show-menubar yes) because GTK
-    # right-click context menus don't expose Filters on that platform.
-    config_names = {
-        "menurc":    ("menurc (strips keyboard shortcuts)", 3),
-        "toolrc":    ("toolrc (pencil + eraser only)",      4),
-        "sessionrc": ("sessionrc (minimal dock layout)",    5),
-    }
-    config_dir = os.path.join(SCRIPT_DIR, "config")
-
-    # Step 2: gimprc — platform-specific handling
+    # 2. Install gimprc — platform-specific.
+    #
+    # macOS:          copy config/gimprc as-is (show-menubar no is correct;
+    #                 right-click canvas exposes Filters there).
+    # Windows/Linux:  write inline with show-menubar yes.  GTK right-click
+    #                 context menus on these platforms do not reliably expose
+    #                 the Filters menu, so the menubar must stay visible.
+    #
+    # On all platforms, lock the file read-only afterwards so GIMP cannot
+    # overwrite it on exit (GIMP saves show-menubar state on shutdown).
     print("[2/%d] Installing gimprc..." % total_steps)
     gimprc_dst = os.path.join(gimp_dir, "gimprc")
 
-    # Always make writable before writing (handles the read-only-from-
-    # previous-install case so we don't get a PermissionError).
     if os.path.isfile(gimprc_dst):
         _make_writable(gimprc_dst)
 
-    if platform.system() == "Windows":
-        # Windows needs show-menubar yes — write inline
-        windows_gimprc = (
-            SPECTRACE_MARKER + " (Windows)\n"
-            "(default-view\n"
-            "    (show-menubar yes)\n"
-            "    (show-statusbar yes)\n"
-            "    (show-rulers no)\n"
-            "    (show-scrollbars yes)\n"
-            "    (show-selection yes)\n"
-            "    (show-layer-boundary no)\n"
-            "    (show-canvas-boundary no)\n"
-            "    (show-guides no)\n"
-            "    (show-grid no)\n"
-            "    (show-sample-points no))\n"
-            "(default-fullscreen-view\n"
-            "    (show-menubar yes)\n"
-            "    (show-statusbar yes)\n"
-            "    (show-rulers no)\n"
-            "    (show-scrollbars yes)\n"
-            "    (show-selection yes)\n"
-            "    (show-layer-boundary no)\n"
-            "    (show-canvas-boundary no)\n"
-            "    (show-guides no)\n"
-            "    (show-grid no)\n"
-            "    (show-sample-points no))\n"
-            "(toolbox-color-area yes)\n"
-            "(toolbox-foo-area no)\n"
-            "(toolbox-image-area no)\n"
-            "(toolbox-wilber no)\n"
-            "(can-change-accels no)\n"
-            "(save-accels yes)\n"
-            "(restore-accels yes)\n"
-            "(save-session-info no)\n"
-            "(save-tool-options no)\n"
-            "(save-device-status no)\n"
-        )
-        with open(gimprc_dst, "w") as f:
-            f.write(windows_gimprc)
-    else:
-        # Mac / Linux: copy from config/gimprc (show-menubar no is fine
-        # because right-click canvas exposes the Filters menu there)
+    if system == "Darwin":
+        # macOS: copy from config/gimprc (show-menubar no)
+        config_dir = os.path.join(SCRIPT_DIR, "config")
         gimprc_src = os.path.join(config_dir, "gimprc")
         if os.path.isfile(gimprc_src):
-            # Prepend the marker so _is_spectrace_config() detects it
             with open(gimprc_src, "r") as f:
                 content = f.read()
             if SPECTRACE_MARKER not in content:
@@ -280,12 +279,16 @@ def install(gimp_dir):
                 f.write(content)
         else:
             print("  -> Skipped (config/gimprc not found)")
-            gimprc_dst = None  # don't try to lock a file we didn't write
+            gimprc_dst = None
+    else:
+        # Windows and Linux: write inline with show-menubar yes
+        platform_label = "Windows" if system == "Windows" else "Linux"
+        content = _GIMPRC_MENUBAR_YES.format(
+            marker="%s (%s)" % (SPECTRACE_MARKER, platform_label)
+        )
+        with open(gimprc_dst, "w") as f:
+            f.write(content)
 
-    # Lock gimprc read-only so GIMP cannot overwrite it on exit.
-    # This is the key fix: GIMP saves its state (including show-menubar)
-    # on shutdown. Making the file read-only causes GIMP to silently skip
-    # that write, preserving our settings across restarts.
     if gimprc_dst and os.path.isfile(gimprc_dst):
         _make_readonly(gimprc_dst)
         print("  -> Done (locked read-only to prevent GIMP overwrite)")
@@ -293,6 +296,12 @@ def install(gimp_dir):
         print("  -> Done")
 
     # Steps 3-5: remaining config files
+    config_dir = os.path.join(SCRIPT_DIR, "config")
+    config_names = {
+        "menurc":    ("menurc (strips keyboard shortcuts)", 3),
+        "toolrc":    ("toolrc (pencil + eraser only)",      4),
+        "sessionrc": ("sessionrc (minimal dock layout)",    5),
+    }
     for fname, (desc, step) in config_names.items():
         print("[%d/%d] Installing %s..." % (step, total_steps, desc))
         src = os.path.join(config_dir, fname)
@@ -351,12 +360,12 @@ def install(gimp_dir):
     print()
     print("=== Installed! Close GIMP completely and reopen. ===")
     print()
-    if platform.system() == "Windows":
-        print("After restart you will see:")
-        print("  - Menubar visible (File, Filters, etc.)")
-    else:
+    if system == "Darwin":
         print("After restart you will see:")
         print("  - No menubar (right-click canvas for menus)")
+    else:
+        print("After restart you will see:")
+        print("  - Menubar visible (File, Filters, etc.)")
     print("  - Only Pencil and Eraser in the toolbox")
     print("  - Only Tool Options (left) and Layers (right)")
     print("  - No brushes, patterns, fonts, or channels docks")

--- a/gimp_plugin/install_linux.sh
+++ b/gimp_plugin/install_linux.sh
@@ -35,9 +35,11 @@ echo "GIMP config:    $GIMP_DIR"
 echo "Spectrace root: $SPECTRACE_ROOT"
 echo ""
 
-# Back up ALL config files we'll replace (only on first install)
+# Back up ALL config files we'll replace (only on first install).
+# Make each writable first in case a previous install locked it read-only.
 for f in gimprc menurc toolrc sessionrc; do
     if [ -f "$GIMP_DIR/$f" ] && [ ! -f "$GIMP_DIR/$f.original" ]; then
+        chmod u+w "$GIMP_DIR/$f" 2>/dev/null || true
         cp "$GIMP_DIR/$f" "$GIMP_DIR/$f.original"
         echo "  Backed up $f -> $f.original"
     fi
@@ -52,13 +54,50 @@ chmod +x "$GIMP_DIR/plug-ins/spectrace_annotator.py"
 echo "  -> Done"
 
 # 2. Install gimprc
-echo "[2/6] Installing gimprc (hides menubar, rulers)..."
-if [ -f "$SCRIPT_DIR/config/gimprc" ]; then
-    cp "$SCRIPT_DIR/config/gimprc" "$GIMP_DIR/"
-    echo "  -> Done"
-else
-    echo "  -> Skipped (no gimprc found)"
-fi
+# Linux needs show-menubar YES (same as Windows): GTK right-click context
+# menus do not reliably expose Filters, so the menubar must stay visible.
+# config/gimprc uses show-menubar no (for macOS only), so we write inline
+# here rather than copying that file.
+# Lock read-only afterwards so GIMP cannot overwrite it on exit.
+echo "[2/6] Installing gimprc (keeps menubar, hides rulers)..."
+chmod u+w "$GIMP_DIR/gimprc" 2>/dev/null || true
+cat > "$GIMP_DIR/gimprc" << 'EOFGIMPRC'
+# Spectrace GIMP configuration (Linux)
+(default-view
+    (show-menubar yes)
+    (show-statusbar yes)
+    (show-rulers no)
+    (show-scrollbars yes)
+    (show-selection yes)
+    (show-layer-boundary no)
+    (show-canvas-boundary no)
+    (show-guides no)
+    (show-grid no)
+    (show-sample-points no))
+(default-fullscreen-view
+    (show-menubar yes)
+    (show-statusbar yes)
+    (show-rulers no)
+    (show-scrollbars yes)
+    (show-selection yes)
+    (show-layer-boundary no)
+    (show-canvas-boundary no)
+    (show-guides no)
+    (show-grid no)
+    (show-sample-points no))
+(toolbox-color-area yes)
+(toolbox-foo-area no)
+(toolbox-image-area no)
+(toolbox-wilber no)
+(can-change-accels no)
+(save-accels yes)
+(restore-accels yes)
+(save-session-info no)
+(save-tool-options no)
+(save-device-status no)
+EOFGIMPRC
+chmod 444 "$GIMP_DIR/gimprc"
+echo "  -> Done (locked read-only to prevent GIMP overwrite)"
 
 # 3. Install stripped shortcuts
 echo "[3/6] Installing menurc (strips keyboard shortcuts)..."
@@ -168,7 +207,7 @@ echo ""
 echo "=== Installed! Close GIMP completely and reopen. ==="
 echo ""
 echo "After restart you will see:"
-echo "  - No menubar (right-click canvas for menus)"
+echo "  - Menubar visible (File, Filters, etc. -- use Filters > Spectrace)"
 echo "  - Only Pencil and Eraser in the toolbox"
 echo "  - Only Tool Options (left) and Layers (right)"
 echo "  - No brushes, patterns, fonts, or channels docks"

--- a/install-gimp-linux.sh
+++ b/install-gimp-linux.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# install-gimp-linux.sh
+# Installs GIMP 2.10.38 (Python 2 / Python-Fu capable) as a desktop app on
+# Debian/Ubuntu so it appears in the application menu. Required before
+# installing the Spectrace plugin on Linux.
+#
+# Usage:
+#   ./install-gimp-linux.sh                 # downloads the AppImage
+#   ./install-gimp-linux.sh /path/to.AppImage   # uses a local copy instead
+#
+set -euo pipefail
+
+# ---- configuration (point APPIMAGE_URL at your own release mirror) --------
+APPIMAGE_URL="https://github.com/TasMania17/Gimp-Appimages-Made-From-Debs/releases/download/Gimp-v2.10.38/gimp-2-10-38-overlay-py2-mm-v3.AppImage"
+INSTALL_DIR="$HOME/Applications/gimp-2.10.38"
+APPIMAGE_NAME="GIMP-2.10.38.AppImage"
+DESKTOP_NAME="GIMP 2.10.38"
+DESKTOP_FILE="$HOME/.local/share/applications/gimp-2.10.38.desktop"
+# ---------------------------------------------------------------------------
+
+say()  { printf '\n\033[1;32m==>\033[0m %s\n' "$1"; }
+warn() { printf '\033[1;33m[!]\033[0m %s\n' "$1"; }
+
+# 1. libfuse2 sanity check (needed on Debian 13 / Ubuntu 24.04+)
+if ! ldconfig -p | grep -q 'libfuse.so.2'; then
+    warn "libfuse2 not found. If the AppImage refuses to start, install it:"
+    warn "    sudo apt install libfuse2t64      # or: sudo apt install libfuse2"
+fi
+
+# 2. Obtain the AppImage (local argument wins over download)
+mkdir -p "$INSTALL_DIR"
+DEST="$INSTALL_DIR/$APPIMAGE_NAME"
+if [ -n "${1:-}" ] && [ -f "${1:-}" ]; then
+    say "Using local AppImage: $1"
+    cp "$1" "$DEST"
+elif [ -f "$DEST" ]; then
+    say "AppImage already installed at $DEST (skipping download)"
+else
+    say "Downloading GIMP 2.10.38 AppImage..."
+    if command -v wget >/dev/null 2>&1; then
+        wget -O "$DEST" "$APPIMAGE_URL"
+    else
+        curl -L -o "$DEST" "$APPIMAGE_URL"
+    fi
+fi
+chmod +x "$DEST"
+
+# 3. Launcher: strips conda/venv off PATH so GIMP uses its bundled Python 2
+#    (Python-Fu plugins fail under a Python 3 from an active conda env).
+LAUNCHER="$INSTALL_DIR/gimp-launcher.sh"
+cat > "$LAUNCHER" <<EOF
+#!/usr/bin/env bash
+HERE="\$(dirname "\$(readlink -f "\$0")")"
+CLEAN_PATH=\$(printf '%s' "\$PATH" | tr ':' '\n' | grep -vE 'conda|anaconda|/envs/' | paste -sd:)
+exec env PATH="/usr/bin:/bin:\$CLEAN_PATH" "\$HERE/$APPIMAGE_NAME" "\$@"
+EOF
+chmod +x "$LAUNCHER"
+
+# 4. Icon: reuse GIMP's own if present anywhere, else fall back to theme name
+ICON_LINE="gimp"
+ICON_SRC="$(find /usr -name 'gimp.png' 2>/dev/null | sort | tail -1 || true)"
+if [ -n "$ICON_SRC" ]; then
+    cp "$ICON_SRC" "$INSTALL_DIR/gimp.png"
+    ICON_LINE="$INSTALL_DIR/gimp.png"
+fi
+
+# 5. Desktop entry
+mkdir -p "$(dirname "$DESKTOP_FILE")"
+cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=$DESKTOP_NAME
+GenericName=Image Editor
+Comment=GIMP 2.10.38 with Python-Fu (used for Spectrace annotation)
+Exec=$LAUNCHER %F
+Icon=$ICON_LINE
+Terminal=false
+Categories=Graphics;2DGraphics;RasterGraphics;Science;
+MimeType=image/png;audio/x-wav;
+StartupNotify=true
+StartupWMClass=gimp
+EOF
+
+# 6. Refresh the application menu
+update-desktop-database "$(dirname "$DESKTOP_FILE")" 2>/dev/null || true
+
+say "Done."
+echo "  AppImage : $DEST"
+echo "  Launcher : $LAUNCHER"
+echo "  Search your applications menu for: $DESKTOP_NAME"


### PR DESCRIPTION
I had to create a whole new workflow for installing GIMP 2.10.38 for debian based linux distros. Furthermore, this approach ended up having the same disappearing menubar bug as the Windows version.

I redid the readme ordering to account for the fact that this new linux workflow required spectrace to be cloned first and a bash installer had to be run.